### PR TITLE
Use timespec_get if compiling with cl on Windows

### DIFF
--- a/src/time_now_stubs.c
+++ b/src/time_now_stubs.c
@@ -21,6 +21,8 @@ CAMLprim value time_now_nanoseconds_since_unix_epoch_or_zero()
 
 #else
 
+#ifndef _MSC_VER
+
 #include <sys/types.h>
 #include <sys/time.h>
 
@@ -33,4 +35,36 @@ CAMLprim value time_now_nanoseconds_since_unix_epoch_or_zero()
     return caml_alloc_int63(NANOS_PER_SECOND * (uint64_t)tp.tv_sec + (uint64_t)tp.tv_usec * 1000);
 }
 
+#else /* compiling with cl */
+
+#if _MSC_VER < 1900 /* timespec_get is supported starting VS 2015 */
+
+/*
+ * Note that there are fallback implementations of gettimeofday for Windows.
+ * E.g., see https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/port/gettimeofday.c;h=75a91993b74414c0a1c13a2a09ce739cb8aa8a08;hb=HEAD
+ * I am not convinced there is much value in supporting Visual Studio versions
+ * older than 2015 in an OCaml library, so we just croak here instead of
+ * falling back.
+ */
+
+#error timespec_get is only available in Visual Studio 2015 (14.0) and later
+#endif
+
+#include <time.h>
+
+/*
+ * https://en.cppreference.com/w/c/chrono/timespec_get
+ * https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/timespec-get-timespec32-get-timespec64-get1?view=msvc-160
+ */
+
+CAMLprim value time_now_nanoseconds_since_unix_epoch_or_zero()
+{
+    struct timespec ts;
+
+    if (timespec_get(&ts, TIME_UTC) != TIME_UTC)
+        return caml_alloc_int63(0);
+    else
+        return caml_alloc_int63(NANOS_PER_SECOND * (uint64_t)ts.tv_sec + (uint64_t)ts.tv_nsec);
+}
+#endif
 #endif


### PR DESCRIPTION
Signed-off-by: A. Sinan Unur <sinan@unur.com>

I built `ocaml` and `opam` using the [MSVC + Cygwin tools instructions](https://github.com/ocaml/ocaml/blob/trunk/README.win32.adoc#compilation-from-the-sources). When I ran `opam install core`, most dependent libraries installed without any problems, but `time_now` failed to install:

```text
$ opam install time_now
[NOTE] External dependency handling not supported for OS family 'windows'.
       You can disable this check using 'opam option --global depext=false'
The following actions will be performed:
  * install time_now v0.14.0

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
▼ retrieved time_now.v0.14.0  (cached)
[ERROR] The compilation of time_now.v0.14.0 failed at "dune build -p time_now -j 1".

#=== ERROR while compiling time_now.v0.14.0 ===================================#
# context     2.1.0~rc2 | win32/x86_64 | ocaml.4.12.0 | https://opam.ocaml.org#6609b442
# path        ~\.opam\default\.opam-switch\build\time_now.v0.14.0
# command     ~\.opam\default\bin\dune.exe build -p time_now -j 1
# exit-code   1
# env-file    ~\.opam\log\time_now-8632-6ce4ee.env
# output-file ~\.opam\log\time_now-8632-6ce4ee.out
### output ###
#           cl src/time_now_stubs.obj (exit 2)
# (cd _build/default/src && "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\
VC\Tools\MSVC\14.29.30037\bin\HostX64\x64\cl.exe" -nologo -O2 -Gy- -MD -D_CRT_SECURE_NO_DEP
RECATE -nologo -O2 -Gy- -MD -I c:/opt/ocaml/lib/ocaml -I C:\opt\cygwin64\home\user\.opam\d
efault\lib\base -I C:\opt\cygwin64\home\user\.opam\default\lib\base\base_internalhash_type
s -I C:\opt\cygwin64\home\user\.[...]
# time_now_stubs.c
# time_now_stubs.c(25): fatal error C1083: Cannot open include file: 'sys/time.h': No such
file or directory



<><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
┌─ The following actions failed
│ λ build time_now v0.14.0
└─
-─ No changes have been performed
```

The apparent reason is that Visual Studio does not provide a `sys/time.h`. However, since VS 2015, `timespec_get` has been available. Therefore, I added a preprocessor check for whether `cl` is being used to compile the C source and implemented `time_now_nanoseconds_since_unix_epoch_or_zero` using that function.

The check uses `_MSC_VER` so that the code continues to compile as usual with `gcc` using MinGW and Cygwin.